### PR TITLE
Fix bug where DebugDrawer's FileProvider could clash with consuming app.

### DIFF
--- a/debugdrawer-timber/src/main/AndroidManifest.xml
+++ b/debugdrawer-timber/src/main/AndroidManifest.xml
@@ -8,8 +8,8 @@
   <application>
 
     <provider
-        android:name="androidx.core.content.FileProvider"
-        android:authorities="au.com.gridstone.debugdrawer.fileprovider"
+        android:name="au.com.gridstone.debugdrawer.DebugDrawerTimberFileProvider"
+        android:authorities="${applicationId}.au.com.gridstone.debugdrawer.fileprovider"
         android:exported="false"
         android:grantUriPermissions="true"
         >

--- a/debugdrawer-timber/src/main/kotlin/au/com/gridstone/debugdrawer/DebugDrawerTimberFileProvider.kt
+++ b/debugdrawer-timber/src/main/kotlin/au/com/gridstone/debugdrawer/DebugDrawerTimberFileProvider.kt
@@ -1,0 +1,10 @@
+package au.com.gridstone.debugdrawer
+
+import androidx.core.content.FileProvider
+
+/**
+ * This class must exist in order to avoid conflicts with consuming applications defining their own
+ * FileProviders. See here for more information:
+ * https://commonsware.com/blog/2017/06/27/fileprovider-libraries.html
+ */
+class DebugDrawerTimberFileProvider : FileProvider()

--- a/debugdrawer-timber/src/main/kotlin/au/com/gridstone/debugdrawer/LogsDialog.kt
+++ b/debugdrawer-timber/src/main/kotlin/au/com/gridstone/debugdrawer/LogsDialog.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.DialogInterface.OnClickListener
 import android.content.Intent
 import android.content.Intent.ACTION_SEND
+import android.content.Intent.EXTRA_STREAM
 import android.content.Intent.FLAG_GRANT_READ_URI_PERMISSION
 import android.content.pm.ResolveInfo
 import android.content.res.Resources
@@ -73,14 +74,15 @@ internal class LogsDialog(context: Context) : AlertDialog(context) {
       // We couldn't produce a logs file for some reason. Give up.
       if (file == null) return@save
 
-      val uri: Uri = FileProvider.getUriForFile(context,
-                                                "au.com.gridstone.debugdrawer.fileprovider",
-                                                file)
+      val uri: Uri = FileProvider.getUriForFile(
+          context,
+          "${context.packageName}.au.com.gridstone.debugdrawer.fileprovider",
+          file)
 
       val sendIntent = Intent(ACTION_SEND)
       sendIntent.type = "text/plain"
-      sendIntent.data = uri
-      sendIntent.flags = sendIntent.flags or FLAG_GRANT_READ_URI_PERMISSION
+      sendIntent.putExtra(EXTRA_STREAM, uri)
+      sendIntent.addFlags(FLAG_GRANT_READ_URI_PERMISSION)
 
       val handlers: List<ResolveInfo> = context.packageManager.queryIntentActivities(sendIntent, 0)
       // Give up if our send intent cannot be handled.


### PR DESCRIPTION
Also fix share not sending correct URI.
Also fix FileProvider authority not being unique.