### PR TITLE
Bump dependencies.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,12 +1,12 @@
 buildscript {
 
   ext.versions = [
-      'compile_sdk'           : 28,
+      'compile_sdk'           : 29,
       'min_sdk'               : 21,
       'android_gradle_plugin' : '3.4.1',
-      'kotlin'                : '1.3.31',
+      'kotlin'                : '1.3.40',
       'bintray_release'       : '1.1.2',
-      'coroutines'            : '1.2.1',
+      'coroutines'            : '1.2.2',
       'appcompat'             : '1.0.2',
       'androidx_core'         : '1.0.2',
       'drawerlayout'          : '1.0.0',
@@ -14,8 +14,8 @@ buildscript {
       'lifecycle'             : '2.0.0',
       'leakcanary'            : '1.6.3',
       'moshi'                 : '1.8.0',
-      'okhttp'                : '3.12.0',
-      'retrofit'              : '2.5.0',
+      'okhttp'                : '4.0.0',
+      'retrofit'              : '2.6.0',
       'retrofit_coroutines'   : '0.9.2',
       'picasso'               : '2.71828',
       'process_phoenix'       : '2.0.0',

--- a/sample-app/src/main/kotlin/au/com/gridstone/debugdrawer/sampleapp/HttpConfiguration.kt
+++ b/sample-app/src/main/kotlin/au/com/gridstone/debugdrawer/sampleapp/HttpConfiguration.kt
@@ -19,7 +19,7 @@ object HttpConfiguration {
   private object AuthInterceptor : Interceptor {
 
     override fun intercept(chain: Chain): Response {
-      val url: HttpUrl = chain.request().url().newBuilder()
+      val url: HttpUrl = chain.request().url.newBuilder()
           .addQueryParameter("api_key", API_KEY)
           .build()
 


### PR DESCRIPTION
Migrating to OkHttp 4.0 meant that a few things had to be tweaked, but nothing major.

One thing to note is that I've bumped Retrofit to 2.6.0, but I haven't migrated the sample app to use the new `suspend` integration. It works fine with real web services, but it breaks when attempting to return from a mock-retrofit delegate. I'll file a bug on Retrofit in a bit and see what they have to say.