### PR TITLE
Bump maven publish plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
       'min_sdk'               : 21,
       'android_gradle_plugin' : '4.1.1',
       'kotlin'                : '1.4.21',
-      'maven_publish_plugin'  : '0.13.0',
+      'maven_publish_plugin'  : '0.19.0',
       'dokka'                 : '1.4.20',
       'coroutines'            : '1.4.2',
       'appcompat'             : '1.2.0',

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip


### PR DESCRIPTION
The build action is failing due to an authentication issue. Seems to be fixed in [latest version of the publish-plugin ](https://github.com/vanniktech/gradle-maven-publish-plugin/issues/203)