### PR TITLE
Update workflow to capture release notes automatically 

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -35,12 +35,17 @@ jobs:
         echo "VERSION_NAME=$VERSION_NAME" >> $GITHUB_ENV
         echo "IS_SNAPSHOT=$IS_SNAPSHOT" >> $GITHUB_ENV
         echo "IS_NEW_VERSION=$IS_NEW_VERSION" >> $GITHUB_ENV
-      
+
+    - name: Generate release notes
+      if: ${{ github.event_name != 'pull_request' && env.IS_SNAPSHOT == 'false'  }}
+      run: ./gradlew -q getChangelog >> RELEASE_NOTES.md
+
     - name: Release on Github
       if: ${{ github.event_name != 'pull_request' && env.IS_SNAPSHOT == 'false' && env.IS_NEW_VERSION == 'true' }}
       uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ env.VERSION_NAME }}
+        body_path: RELEASE_NOTES.md
         files: |
           debugdrawer/build/outputs/aar/debugdrawer-debug.aar
           debugdrawer-leakcanary/build/outputs/aar/debugdrawer-leakcanary-release.aar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
-Change Log
-==========
+# Changelog
 
-Version 0.9.7
--------------
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
+adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+- Add support for Android 12
+- Update to use latest LeakCanary
+
+## [0.9.7] - 2022-04-11
 
 - Add support for gesture navigation (you can now swipe on the top edge of the screen to open the debug drawer)
 - Hopefully fix sources not getting uploaded to Maven Central
@@ -11,8 +18,7 @@ Version 0.9.7
 - Add heap dump toggle switch to LeakCanary module
 - Fix appearance of button in LeakCanary module
 
-Version 0.9.6
--------------
+## [0.9.6]
 
 - Add support for window insets on all edges (great for apps supporting edge-to-edge).
 - Remove the need to call `LumberYard.install()` when using the Timber module.
@@ -21,37 +27,31 @@ Version 0.9.6
 - Fix bug where resource IDs would display as errors in Android Studio.
 - Migrate deployment to Maven Central.
 
-Version 0.9.5
--------------
+## [0.9.5]
 
 - Add pretty printing JSON option in HTTP logger module
 
-Version 0.9.4
--------------
+## [0.9.4]
 
 - Fix crash on older versions of Android (at least on API 21 and 22)
 - Fix state restoration of drawer and scroll view
 - Bump various dependencies
 
-Version 0.9.3
--------------
+## [0.9.3]
 
 - Fix bug where Timber logs were not sharing
 - Fix Timber log FileProvider [potentially clashing](https://commonsware.com/blog/2017/06/27/fileprovider-libraries.html) with consuming application
 
-Version 0.9.2
--------------
+## [0.9.2]
 
 - Add OkHttp log interceptor module
 - Bump various dependencies, including AndroidX to the new stable release
 
-Version 0.9.1
--------------
+## [0.9.1]
 
 - Fix drawer not building correctly when no custom container provided in builder.
 
-Version 0.9.0
--------------
+## [0.9.0]
 
 Initial release of DebugDrawer, including modules for
  - Device info: Things like resolution and API level.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Add support for Android 12
 - Update to use latest LeakCanary
 
-## [0.9.7] - 2022-04-11
+## [0.9.7] - 2020-01-16
 
 - Add support for gesture navigation (you can now swipe on the top edge of the screen to open the debug drawer)
 - Hopefully fix sources not getting uploaded to Maven Central

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,12 @@ buildscript {
   }
 }
 
+plugins {
+  id 'org.jetbrains.changelog' version '1.3.1'
+}
+
+apply plugin: 'org.jetbrains.changelog'
+
 allprojects {
   repositories {
     google()


### PR DESCRIPTION
Making use of the [changelog-plugin](https://github.com/JetBrains/gradle-changelog-plugin) for this