### PR TITLE
Fix workflow gpg password

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -56,15 +56,13 @@ jobs:
     - name: Release to sonatype
       if: ${{ github.event_name != 'pull_request' }}
       run: |
-        echo signingInMemoryKeyId="${GPG_KEY_ID}" > "$HOME/.gradle/gradle.properties"
-        echo signingInMemoryKeyPassword="${GPG_KEY_PASSPHRASE}" >> "$HOME/.gradle/gradle.properties"
+        echo signingInMemoryKeyPassword="${GPG_PASSWORD}" >> "$HOME/.gradle/gradle.properties"
         echo signingInMemoryKey="${GPG_KEY}" >> "$HOME/.gradle/gradle.properties"
         echo mavenCentralUsername="${MAVEN_CENTRAL_USERNAME}" >> "$HOME/.gradle/gradle.properties"
         echo mavenCentralPassword="${MAVEN_CENTRAL_PASSWORD}" >> "$HOME/.gradle/gradle.properties"
         ./gradlew androidSourcesJar androidJavadocJar publish --info --no-daemon --no-parallel
       env:
-        GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
-        GPG_KEY_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+        GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
         GPG_KEY: ${{ secrets.GPG_KEY }}
         MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
         MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}


### PR DESCRIPTION
Welp this was a little embarrassing. Couldn't figure out why CI couldn't sign when it was signing just fine on my local machine. Turns out I was giving CI `GPG_KEY_PASSPHRASE` instead of `GPG_KEY_PASSWORD`

I also removed `GPG_KEY_ID` as this turns out to be optional.

Hopefully this works 🤞 