### PR TITLE
Fix workflow to close and release staged repository

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -60,7 +60,7 @@ jobs:
         echo signingInMemoryKey="${GPG_KEY}" >> "$HOME/.gradle/gradle.properties"
         echo mavenCentralUsername="${MAVEN_CENTRAL_USERNAME}" >> "$HOME/.gradle/gradle.properties"
         echo mavenCentralPassword="${MAVEN_CENTRAL_PASSWORD}" >> "$HOME/.gradle/gradle.properties"
-        ./gradlew androidSourcesJar androidJavadocJar publish --info --no-daemon --no-parallel
+        ./gradlew androidSourcesJar androidJavadocJar publish closeAndReleaseRepository --info --no-daemon --no-parallel
       env:
         GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
         GPG_KEY: ${{ secrets.GPG_KEY }}


### PR DESCRIPTION
Can't see the staging repo on sonatype 🤔 Not sure why. But this gradle task `closeAndReleaseRepository` [lets you release a version automatically ](https://github.com/vanniktech/gradle-maven-publish-plugin#releasing)- without you having to manually release on the sonatype console. Hoping this works 🤞 